### PR TITLE
fixed a bug with optional arguments ordering, added a test case for this bug

### DIFF
--- a/argue.js
+++ b/argue.js
@@ -83,7 +83,8 @@
         var value = args[pivotIndex];
         
         if (!belongs(value, type)){
-          expansion.splice(i, 1); 
+          if(i !== 1)
+            expansion.splice(i, 1);
           if(!optional && !expansion.length)
             throw new Error("parameter '" + name + "' waiting for a " + type.name + " argument but received a " + toType(value));
         }

--- a/test/orderingSpec.js
+++ b/test/orderingSpec.js
@@ -75,6 +75,34 @@ define(['argue', 'chai'], function(__, chai) {
           range(3, 7, 1, 0);
         }).should.throw('Too many arguments');
       });
+
+      it('should hit the target among similars test case #2', function() {
+        function f() {
+            return __({
+                first: [String],
+                middle: [String],
+                last: String
+            });
+        }
+
+        //right:
+        var lastArg = 'should be last';
+        var oneArg = f(lastArg);
+        should.equal(oneArg.first, undefined);
+        should.equal(oneArg.middle, undefined);
+        should.equal(oneArg.last, lastArg);
+
+        var firstArg = 'should be first'
+        var twoArg = f(firstArg, lastArg);
+        should.equal(twoArg.first, firstArg);
+        should.equal(twoArg.middle, undefined);
+        should.equal(twoArg.last, lastArg);
+
+        //wrong:
+        (function(){
+            f(3, 7, 1, 0);
+        }).should.throw('Too many arguments');
+      });
   
       it('should not worry about not set optional arguments', function() {
         function upper() {


### PR DESCRIPTION
actually ArgueJS code is not so much commented so I didn't figure out exactly why `expansion.slice is called` for this case. But from what I've tracked, my changes are enough to squash this bug
